### PR TITLE
Fix typo in rebuild.sh scripts

### DIFF
--- a/example_00/rebuild.sh
+++ b/example_00/rebuild.sh
@@ -9,15 +9,15 @@ CDE="\033[39m"
 CYE="\033[33m"
 CBL="\033[34m"
 
-echo "${CYE}Trying to remove CONTAINER tagged: ${CBL}${IMAGE}${CDE}"
+echo -e "${CYE}Trying to remove CONTAINER tagged: ${CBL}${IMAGE}${CDE}"
 docker rm $IMAGE
 
-echo "${CYE}Trying to remove IMAGE: ${CBL}${IMAGE}${CDE}"
+echo -e "${CYE}Trying to remove IMAGE: ${CBL}${IMAGE}${CDE}"
 docker rmi $IMAGE
 
-echo "${CYE}Trying to build IMAGE, tagging: ${CBL}${IMAGE}${CDE}"
+echo -e "${CYE}Trying to build IMAGE, tagging: ${CBL}${IMAGE}${CDE}"
 time docker build -t $IMAGE .
 
-echo "${CYE}Trying to start CONTAINER tagged: ${CBL}${IMAGE}${CDE}"
+echo -e "${CYE}Trying to start CONTAINER tagged: ${CBL}${IMAGE}${CDE}"
 docker run --name $IMAGE $STARTARGS $IMAGE
 

--- a/example_01/rebuild.sh
+++ b/example_01/rebuild.sh
@@ -9,15 +9,15 @@ CDE="\033[39m"
 CYE="\033[33m"
 CBL="\033[34m"
 
-echo "${CYE}Trying to remove CONTAINER tagged: ${CBL}${IMAGE}${CDE}"
+echo -e "${CYE}Trying to remove CONTAINER tagged: ${CBL}${IMAGE}${CDE}"
 docker rm $IMAGE
 
-echo "${CYE}Trying to remove IMAGE: ${CBL}${IMAGE}${CDE}"
+echo -e "${CYE}Trying to remove IMAGE: ${CBL}${IMAGE}${CDE}"
 docker rmi $IMAGE
 
-echo "${CYE}Trying to build IMAGE, tagging: ${CBL}${IMAGE}${CDE}"
+echo -e "${CYE}Trying to build IMAGE, tagging: ${CBL}${IMAGE}${CDE}"
 time docker build -t $IMAGE .
 
-echo "${CYE}Trying to start CONTAINER tagged: ${CBL}${IMAGE}${CDE}"
+echo -e "${CYE}Trying to start CONTAINER tagged: ${CBL}${IMAGE}${CDE}"
 docker run --name $IMAGE $STARTARGS $IMAGE
 

--- a/example_02/rebuild.sh
+++ b/example_02/rebuild.sh
@@ -9,15 +9,15 @@ CDE="\033[39m"
 CYE="\033[33m"
 CBL="\033[34m"
 
-echo "${CYE}Trying to remove CONTAINER tagged: ${CBL}${IMAGE}${CDE}"
+echo -e "${CYE}Trying to remove CONTAINER tagged: ${CBL}${IMAGE}${CDE}"
 docker rm $IMAGE
 
-echo "${CYE}Trying to remove IMAGE: ${CBL}${IMAGE}${CDE}"
+echo -e "${CYE}Trying to remove IMAGE: ${CBL}${IMAGE}${CDE}"
 docker rmi $IMAGE
 
-echo "${CYE}Trying to build IMAGE, tagging: ${CBL}${IMAGE}${CDE}"
+echo -e "${CYE}Trying to build IMAGE, tagging: ${CBL}${IMAGE}${CDE}"
 time docker build -t $IMAGE .
 
-echo "${CYE}Trying to start CONTAINER tagged: ${CBL}${IMAGE}${CDE}"
+echo -e "${CYE}Trying to start CONTAINER tagged: ${CBL}${IMAGE}${CDE}"
 docker run --name $IMAGE $STARTARGS $IMAGE
 

--- a/example_03/rebuild.sh
+++ b/example_03/rebuild.sh
@@ -9,15 +9,15 @@ CDE="\033[39m"
 CYE="\033[33m"
 CBL="\033[34m"
 
-echo "${CYE}Trying to remove CONTAINER tagged: ${CBL}${IMAGE}${CDE}"
+echo -e "${CYE}Trying to remove CONTAINER tagged: ${CBL}${IMAGE}${CDE}"
 docker rm $IMAGE
 
-echo "${CYE}Trying to remove IMAGE: ${CBL}${IMAGE}${CDE}"
+echo -e "${CYE}Trying to remove IMAGE: ${CBL}${IMAGE}${CDE}"
 docker rmi $IMAGE
 
-echo "${CYE}Trying to build IMAGE, tagging: ${CBL}${IMAGE}${CDE}"
+echo -e "${CYE}Trying to build IMAGE, tagging: ${CBL}${IMAGE}${CDE}"
 time docker build -t $IMAGE .
 
-echo "${CYE}Trying to start CONTAINER tagged: ${CBL}${IMAGE}${CDE}"
+echo -e "${CYE}Trying to start CONTAINER tagged: ${CBL}${IMAGE}${CDE}"
 docker run --name $IMAGE $STARTARGS $IMAGE
 

--- a/example_04/rebuild.sh
+++ b/example_04/rebuild.sh
@@ -9,15 +9,15 @@ CDE="\033[39m"
 CYE="\033[33m"
 CBL="\033[34m"
 
-echo "${CYE}Trying to remove CONTAINER tagged: ${CBL}${IMAGE}${CDE}"
+echo -e "${CYE}Trying to remove CONTAINER tagged: ${CBL}${IMAGE}${CDE}"
 docker rm $IMAGE
 
-echo "${CYE}Trying to remove IMAGE: ${CBL}${IMAGE}${CDE}"
+echo -e "${CYE}Trying to remove IMAGE: ${CBL}${IMAGE}${CDE}"
 docker rmi $IMAGE
 
-echo "${CYE}Trying to build IMAGE, tagging: ${CBL}${IMAGE}${CDE}"
+echo -e "${CYE}Trying to build IMAGE, tagging: ${CBL}${IMAGE}${CDE}"
 time docker build -t $IMAGE .
 
-echo "${CYE}Trying to start CONTAINER tagged: ${CBL}${IMAGE}${CDE}"
+echo -e "${CYE}Trying to start CONTAINER tagged: ${CBL}${IMAGE}${CDE}"
 docker run --name $IMAGE $STARTARGS $IMAGE
 


### PR DESCRIPTION
Added the -e option to the echo commands to allow backslash escaped and thus show colored text.